### PR TITLE
Fixed hidden organizations not being found

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var toFunction = function(str) {
 };
 
 module.exports = function(clientId, clientSecret, config) {
-	var scope = (config.team && !config.credentials)  ? 'user' : 'public';
+	var scope = ((config.team || config.organization) && !config.credentials)  ? 'user' : 'public';
 	var secret = config.secret || Math.random().toString();
 	var userAgent = config.ua || 'github-auth';
 	var redirectUri = config.redirectUri || '';


### PR DESCRIPTION
The API only shows organizations that the user has switched to public unless the scope user is used.